### PR TITLE
chore: slight improvements to bak cli

### DIFF
--- a/packages/bak/bin/bak
+++ b/packages/bak/bin/bak
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../lib/cli')
+require('../lib/cli').parseAndExit().catch(console.error)

--- a/packages/bak/lib/cli/commands/start.js
+++ b/packages/bak/lib/cli/commands/start.js
@@ -1,23 +1,23 @@
 const { resolve } = require('path')
 const chalk = require('chalk')
 const os = require('os')
-const { Bak } = require('../..')
 
 module.exports = {
   flags: 'start [dir]',
   desc: 'Start Server',
-  setup (cli) {
-
-  },
+  paramsDesc: 'Root directory of app, containing config file',
   async run (argv) {
     const rootDir = resolve(process.cwd(), argv.dir || '')
-    const configPath = resolve(rootDir, argv.config || 'bak.config.js')
+    const configPath = resolve(rootDir, argv.config)
     const config = require(configPath)
 
     // Root Dir
     if (!config.relativeTo) {
       config.relativeTo = rootDir
     }
+
+    // Delay loading framework until command is actually run
+    const { Bak } = require('../..')
 
     // Create server instance
     const bak = new Bak(config)

--- a/packages/bak/lib/cli/index.js
+++ b/packages/bak/lib/cli/index.js
@@ -3,21 +3,22 @@ const cli = require('sywac')
 const styles = require('./styles')
 
 // Commands
-cli.command(require('./commands/start'))
+cli.commandDirectory('commands')
+
+// Global options
+cli.file('-c, --config <file>', {
+  desc: 'Config file',
+  defaultValue: 'bak.config.js'
+})
 
 // Help text stuff
 cli.style(styles)
 cli.help('-h, --help')
 cli.version('-v, --version')
 cli.showHelpByDefault()
+cli.outputSettings({ maxWidth: 75 })
 
-// Global options
-cli.file('-c, --config', {
-  mustExist: true,
-  desc: 'Config file'
-})
-
-// Run CLI
-cli.parseAndExit()
-// .then(console.log)
-  .catch(console.error)
+// Export cli config
+// Call parseAndExit() in bin/bak
+// Or call parse(args) in tests
+module.exports = cli

--- a/packages/bak/lib/cli/styles.js
+++ b/packages/bak/lib/cli/styles.js
@@ -11,7 +11,13 @@ module.exports = {
   // Style normal help text
   group: str => chalk.white(str),
   flags: (str, type) => {
-    let style = type.datatype === 'command' ? chalk.magenta : chalk.green
+    // Magenta for commands
+    // Green for args
+    // Dim green for options
+    if (type.datatype === 'command') {
+      return str.split(' ').map(flag => flag.startsWith('[') || flag.startsWith('<') ? chalk.green(flag) : chalk.magenta(flag)).join(' ')
+    }
+    let style = chalk.green
     if (str.startsWith('-')) style = style.dim
     return style(str)
   },

--- a/packages/bak/lib/server.js
+++ b/packages/bak/lib/server.js
@@ -3,7 +3,6 @@ const Hapi = require('hapi')
 const { resolve } = require('path')
 const { serial, parallel } = require('items-promise')
 const { normalizePath } = require('./utils')
-const Controller = require('./controller')
 
 module.exports = class Server {
   /**

--- a/packages/bak/package.json
+++ b/packages/bak/package.json
@@ -24,6 +24,6 @@
     "mongoose": "^4.11.9",
     "pretty-error": "^2.1.1",
     "strip-ansi": "^4.0.0",
-    "sywac": "^1.1.0"
+    "sywac": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,9 +3350,9 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-sywac@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sywac/-/sywac-1.1.0.tgz#3c837efa8a5a71a3141bf4acbd954ec7c97d76be"
+sywac@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sywac/-/sywac-1.2.0.tgz#b0a05c4e0f459918e8e42e0f55e1c1039a0e975c"
 
 table@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This PR proposes the following changes:

#### packages/bak/lib/cli/index.js

1. Change index.js into a module (instead of an implicit runnable script) by exporting the sywac configuration instance

    This should make unit testing the CLI configuration easier (once we get around to it) because it will allow us to do things like:

    ```js
    const cli = require('../lib/cli')

    test('bak help start', async assert => {
      const result = await cli.parse('help start')
      assert.equal(result.output, expectedHelpOutput)
    })
    ```

    and assert on the results of parsing/execution.

    Obviously, this change affects **packages/bak/bin/bak** too, which has been updated accordingly.

2. Use the [commandDirectory](http://sywac.io/docs/sync-config.html#commandDirectory) method available in sywac@1.2.0

    This will allow us to add new command modules in the future without having to manually `require()` and add each one to the CLI configuration. 👍

    To make sure this functionality is available to bak, I attempted to upgrade the sywac dependency to `^1.2.0`, but I'm not sure I updated the **yarn.lock** file correctly (yarn workspaces + lerna is a bit new to me).

3. Disable `mustExist: true` for the global `--config` option

    This needs to be disabled because the `start` command is interpreting the `--config` option as relative to the given `dir` positional argument, which means the path checked by sywac and the path used by the `start` command will not be the same when `dir` is specified.

4. Move the default value for `--config` to the global declaration

    This way, you won't have to redefine it if other commands are added. Sywac will make sure to populate `argv.config` with the default value if the option isn't defined on the command line.

5. Define the `--config` global option _before_ `help` and `version`

    Just so it's displayed _above_ the help and version options in help text. I also added a placeholder to the flags for the option, so it's clear that a value is expected when the option is used on the command line.

6. Define a suitable max width for CLI help text

    Just so it looks a little better - otherwise the "hints" are spread out too far.

#### packages/bak/lib/cli/commands/start.js

1. "Lazily" require the framework in the `start` command run handler

    Since loading the framework is a little heavy, this speeds up the CLI (by about 50% on my machine) for any cases when the `start` command is _not_ run, e.g. `bak` or `bak version` or `bak help start` or `bak start --help`.

2. Define a description for the optional `dir` argument

    Gives some context to the argument when running `bak help start` or `bak start --help`.

3. Remove the unused `setup` method

    It's meant to be used to define custom options, subcommands, or other CLI configuration that is specific to the command. Since it wasn't used and isn't technically necessary (for sywac), I removed it.

#### packages/bak/lib/cli/styles.js

1. Use a green style for positional arguments in command flags

    This makes styling consistent for all commands (magenta), arguments (green), options (dim green).

#### packages/bak/lib/server.js

1. Removed an unused variable

    Found while checking `npm run lint`.

Note that if I didn't update the **yarn.lock** file correctly, I can easily remove the last commit from this branch, if you'd like.

Hope this helps! Thanks for using sywac!